### PR TITLE
ft(base storage): add base_remote_storage prop to CloudinaryStorage

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -49,5 +49,6 @@ CLOUDINARY_STORAGE = {
     'CLOUD_NAME': 'test',
     'API_KEY': 'test_api_key',
     'API_SECRET': 'test_api_secret',
+    'BASE_STORAGE_LOCATION': '/test/',
     'SECURE': True
 }

--- a/tests/test_cloudinary_storage.py
+++ b/tests/test_cloudinary_storage.py
@@ -12,7 +12,7 @@ class CloudinaryStorageTestCase(SimpleTestCase):
     def test_upload_path(self):
         filename = 'css/test.css'
         prefixed_name = self.storage.upload_path(filename)
-        self.assertTrue(prefixed_name.startswith(self.storage.base_url))
+        self.assertTrue(prefixed_name.startswith(self.storage.remote_base_location))
 
     @patch('gamma_cloudinary.storage.CloudinaryStorage.cloudinary.CloudinaryResource')
     def test_url(self, mocked_resource):

--- a/tests/test_static_cloudinary_storage.py
+++ b/tests/test_static_cloudinary_storage.py
@@ -38,7 +38,7 @@ class StaticCloudinaryStorageTestCase(SimpleTestCase):
 
         self.assertEqual(
             pattern.sub(converter, content),
-            'url("https://res.cloudinary.com/test/raw/upload/v1/static/css/random.css?t=56#test")'
+            'url("https://res.cloudinary.com/test/raw/upload/v1/test/static/css/random.css?t=56#test")'
             )
 
     def test_url_converter_correctly_replaces_relative_static_urls_without_leading_slash_with_cloudinary_urls(self):
@@ -48,7 +48,7 @@ class StaticCloudinaryStorageTestCase(SimpleTestCase):
         converter = self.storage.url_converter(name)
         self.assertEqual(
             pattern.sub(converter, content),
-            'url("https://res.cloudinary.com/test/raw/upload/v1/static/css/random.css?t=56#test")'
+            'url("https://res.cloudinary.com/test/raw/upload/v1/test/static/css/random.css?t=56#test")'
             )
 
     def test_url_converter_ignores_absolute_urls(self):


### PR DESCRIPTION
add base_remote_storage property to CloudinaryStorage class. This
allows a user to specify where they would like have their files
stored on their cloudinary account.