### PR TITLE
fix(CloudinaryStorage): refactor custom_path method for simplicity

### DIFF
--- a/gamma_cloudinary/config.py
+++ b/gamma_cloudinary/config.py
@@ -11,8 +11,6 @@ def setup_cloudinary():
             #check for the existence of CLOUDINARY_STORAGE object in django settings module
             cloudinary_settings = getattr(settings, 'CLOUDINARY_STORAGE')
 
-            #print(cloudinary_settings)
-
             #if CLOUDINARY_STORAGE exists check for the minimum required keys to get cloudinary up and running
             itemgetter('CLOUD_NAME', 'API_KEY', 'API_SECRET')(cloudinary_settings)
         except AttributeError:

--- a/gamma_cloudinary/storage/RewriteToCloudinaryUrlMixin.py
+++ b/gamma_cloudinary/storage/RewriteToCloudinaryUrlMixin.py
@@ -113,7 +113,6 @@ class RewriteToCloudinaryUrlMixin:
                     return matched
 
                 url_parts = urlparse(url)
-                print(url_parts.path, settings.STATIC_URL)
                 if url_parts.path.startswith('/'):
                     assert url_parts.path.startswith(settings.STATIC_URL)
                     target_name = url_parts.path[len(settings.STATIC_URL):]

--- a/tests/test_cloudinary_storage.py
+++ b/tests/test_cloudinary_storage.py
@@ -12,7 +12,7 @@ class CloudinaryStorageTestCase(SimpleTestCase):
     def test_custom_path(self):
         filename = 'css/test.css'
         prefixed_name = self.storage.custom_path(filename)
-        self.assertTrue(prefixed_name.startswith(self.storage.base_url.lstrip('/')))
+        self.assertTrue(prefixed_name.startswith(self.storage.base_url))
 
     @patch('gamma_cloudinary.storage.CloudinaryStorage.cloudinary.CloudinaryResource')
     def test_url(self, mocked_resource):


### PR DESCRIPTION
Refactor CloudinaryStorage class to remove complexities introduced by unnecessary lines of code making some of the class methods hard to understand. Especially the custom_path method. This method should simply append the right prefix if the prefix is missing from the provided path.